### PR TITLE
Fix #5 NumberLong inflate/deflate problem

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -58,7 +58,7 @@ module.exports = {
       return bson.Timestamp(val.$timestamp.$t, val.$timestamp.$i);
     },
     '$numberLong': function(val){
-      return bson.Long(val.$numberLong);
+      return bson.Long.fromString(val.$numberLong);
     },
     '$maxKey': function(){
       return bson.MaxKey();

--- a/test/deflate.test.js
+++ b/test/deflate.test.js
@@ -8,7 +8,15 @@ describe('Defalte', function(){
     ref = bson.DBRef('local.startup_log', _id);
 
   it('converts `{$numberLong: <str>}` to `bson.Long`', function(){
-    assert(deflate({$numberLong: 10}).equals(bson.Long.fromNumber(10)));
+    assert(deflate({$numberLong: "10"}).equals(bson.Long.fromString("10")));
+  });
+
+  it('converts `{$numberLong: <str>}` to `bson.Long` (between 2^32 and 2^53)', function(){
+    assert(deflate({$numberLong: "4294967297"}).equals(bson.Long.fromString("4294967297")));
+  });
+
+  it('converts `{$numberLong: <str>}` to `bson.Long` (greater than 2^53)', function(){
+    assert(deflate({$numberLong: "18014398509481984"}).equals(bson.Long.fromString("18014398509481984")));
   });
 
   it('converts `{$oid: <_id>}` to `bson.ObjectId`', function(){

--- a/test/inflate.test.js
+++ b/test/inflate.test.js
@@ -18,7 +18,15 @@ describe('Inflate', function(){
   });
 
   it('converts `bson.Long` to `{$numberLong: <str>}`', function(){
-    assert.deepEqual(inflate(bson.Long.fromNumber(10)), {$numberLong: 10});
+    assert.deepEqual(inflate(bson.Long.fromString("10")), {$numberLong: "10"});
+  });
+
+  it('converts `bson.Long` to `{$numberLong: <str>}` (between 2^32 and 2^53)', function(){
+    assert.deepEqual(inflate(bson.Long.fromString("4294967297")), {$numberLong: "4294967297"});
+  });
+
+  it('converts `bson.Long` to `{$numberLong: <str>}` (greater than 2^53)', function(){
+    assert.deepEqual(inflate(bson.Long.fromString("18014398509481984")), {$numberLong: "18014398509481984"});
   });
 
   it('converts `bson.ObjectId` to `{$oid: <_id>}`', function(){


### PR DESCRIPTION
When serializing/unserializing some Longs with a value greater than 2^32
(starting from 4294967297, 2^32+1), it fails. Serialization doesn't give
the same number than the one serialized.

Use bson.Long.fromString in type.js for Long deflation.