### PR TITLE
added parse functionality for log -> strict and shell -> strict, plus tests.

### DIFF
--- a/lib/deflate.js
+++ b/lib/deflate.js
@@ -1,4 +1,5 @@
 var types = require('./types');
+var strict = require('./modes/strict');
 var isObject = types.isObject;
 var async = require('async');
 var raf = require('raf');
@@ -17,7 +18,7 @@ module.exports = function deflate(data) {
   var keys = Object.keys(data);
   if (keys.length === 0) return data;
 
-  var caster = types.deflate[keys[0]];
+  var caster = strict.deflate[keys[0]];
   if (!caster) {
     return keys.reduce(function(schema, key) {
       schema[key] = deflate(data[key]);
@@ -44,7 +45,7 @@ function deflate_async(data, fn) {
     if (keys.length === 0) {
       fn(null, data);
     } else {
-      var caster = types.deflate[keys[0]];
+      var caster = strict.deflate[keys[0]];
       if (caster) {
         fn(null, caster.call(null, data));
       } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,46 @@
 var deflate = require('./deflate');
 var inflate = require('./inflate');
+var shell = require('./modes/shell');
+var log = require('./modes/log');
 var es = require('event-stream');
 var JSONStream = require('JSONStream');
 var raf = require('raf');
+var format = require('util').format;
 
-module.exports.parse = function(text, reviver) {
-  return deflate(JSON.parse(text, reviver));
+function preprocess(text, mode) {
+  mode = mode || 'strict';
+
+  switch (mode) {
+    case 'strict': return text;
+    case 'shell': return shell.toStrict(text);
+    case 'log': return log.toStrict(text);
+    default:
+      throw new Error(
+        format('unknown mode `%s`. Use `strict` (default), `shell` or `log`.', mode)
+      );
+  }
+}
+
+/**
+ * parses a string in strict, shell or log mode extended JSON and returns object with BSON values
+ * @param  {String} text  string to parse
+ * @param  {Function}     reviver callback function for custom parsing, @see ./reviver.js
+ * @param  {Enum} mode    one of `strict`, `shell`, `log`
+ * @return {Object}       Object with native and/or BSON values
+ */
+module.exports.parse = function(text, reviver, mode) {
+  return deflate(JSON.parse(preprocess(text, mode), reviver));
 };
 
+/**
+ * stringifies an object with native and/or BSON values back into strict extended JSON
+ * @param  {Object} value               Object or value to stringify
+ * @param  {Function|Array} replacer    Custom replacement
+ * @param  {Number|String} space        Custom spacing
+ * @return {String}                     JSON representation of value
+ *
+ * @see http://mzl.la/1fms8sL  JSON.stringify() documentation
+ */
 module.exports.stringify = function(value, replacer, space) {
   return JSON.stringify(inflate(value), replacer, space);
 };
@@ -85,4 +118,3 @@ module.exports.createParseStream = function(path, map) {
     });
   return wrapper;
 };
-

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -1,3 +1,4 @@
+var strict = require('./modes/strict');
 var types = require('./types');
 var isObject = types.isObject;
 var type = types.type;
@@ -12,7 +13,7 @@ var type = types.type;
 var inflate = module.exports = function(value) {
   if (Array.isArray(value)) return value.map(inflate.bind(null));
   if (!isObject(value)) {
-    var caster = types.inflate[type(value)];
+    var caster = strict.inflate[type(value)];
     if (!caster) return value;
     return caster(value);
   }

--- a/lib/modes/index.js
+++ b/lib/modes/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  strict: require('./strict'),
+  log: require('./log'),
+  shell: require('./shell')
+};

--- a/lib/modes/log.js
+++ b/lib/modes/log.js
@@ -1,0 +1,74 @@
+var moment = require('moment');
+
+function toStrictQuotes(str) {
+  return str
+    // wrap field names in double quotes
+    .replace(/([{,])\s*([^,{\s\'"]+)\s*:/g, '$1 "$2":');
+}
+
+function toStrictSimple(str) {
+  return str
+    // Timestamps
+    .replace(/Timestamp (\d+)\|(\d+)/g, '{ "$timestamp": { "t": $1, "i": $2 } }')
+    // MinKey
+    .replace(/MinKey/g, '{ "$minKey": 1 }')
+    // MaxKey
+    .replace(/MaxKey/g, '{ "$maxKey": 1 }')
+    // ObjectIds
+    .replace(/ObjectId\('([0-9abcdef]{24})'\)/g, '{ "$oid": "$1" }');
+}
+
+function toStrictNumberLong(str) {
+  var match = str.match(/\s\d{10,}/g);
+  if (!match) return str;
+  match.forEach(function(m) {
+    var n = m.trim();
+    if (+n > 2147483647) {
+      str = str.replace(n, '{ "$numberLong": "' + n + '" }');
+    }
+  });
+  return str;
+}
+
+function toStrictRegEx(str) {
+  var regex = /([,:]\s*)\/(.+?)\/([gims]{0,4})(\s+)/g;
+  var match;
+
+  while ((match = regex.exec(str)) !== null) {
+    var m2 = match[2].replace(/"/g, '"');
+    str = str.replace(match[0], match[1] + '{ "$regex": "' + m2 + '", "$options": "'
+      + match[3] + '" }' + match[4]);
+  }
+  return str;
+}
+
+function toStrictDate(str) {
+  var regex = /new Date\((\d+)\)/g;
+  var match;
+  while ((match = regex.exec(str)) !== null) {
+    var t = moment(parseInt(match[1], 10));
+    str = str.replace(match[0], '{ "$date": "' + t.toISOString() + '" }');
+  }
+  return str;
+}
+
+function toStrictBinData(str) {
+  var regex = /BinData\((\d+), ([0-9ABCDEF]+)\)/g;
+  var match;
+  while ((match = regex.exec(str)) !== null) {
+    // convert hex to base64
+    var hex = new Buffer(match[2], 'hex').toString('base64');
+    str = str.replace(match[0], '{ "$binary": "' + hex + '", "$type": "' + match[1] + '" }');
+  }
+  return str;
+}
+
+module.exports.toStrict = function(str) {
+  str = toStrictQuotes(str);
+  str = toStrictSimple(str);
+  str = toStrictNumberLong(str);
+  str = toStrictRegEx(str);
+  str = toStrictDate(str);
+  str = toStrictBinData(str);
+  return str;
+};

--- a/lib/modes/shell.js
+++ b/lib/modes/shell.js
@@ -1,0 +1,112 @@
+var format = require('util').format;
+
+function toStrictQuotes(str) {
+  return str
+    // replace single quotes with double quotes
+    .replace(/'/g, '"')
+    // wrap field names in double quotes
+    .replace(/([{,])\s*([^,{\s\'"]+)\s*:/g, '$1 "$2":');
+}
+
+function toStrictSimple(str) {
+  return str
+    // Timestamps
+    .replace(/Timestamp\((\d+), (\d+)\)/g, '{ "$timestamp": { "t": $1, "i": $2 } }')
+
+    // MinKey and MaxKey are erroneously already printed in strict json format
+    // @see https://jira.mongodb.org/browse/SERVER-19171
+    // .replace(/MinKey/g, '{ "$minKey": 1 }')
+    // .replace(/MaxKey/g, '{ "$maxKey": 1 }')
+
+    // ObjectIds
+    .replace(/ObjectId\("([0-9abcdef]{24})"\)/g, '{ "$oid": "$1" }')
+    // NumberLong
+    .replace(/NumberLong\(([0-9]+)\)/g, '{ "$numberLong": "$1" }')
+    // Date also prints the wrong format,
+    // @see https://jira.mongodb.org/browse/SERVER-19171
+    .replace(/ISODate\("(.+?)"\)/g, '{ "$date": "$1" }')
+    // DBRef
+    .replace(/DBRef\("(.+?)", "(.+?)"\)/g, '{ "$ref": "$1", "$id": "$2" }')
+    // undefined, shell is buggy here too,
+    // @see https://jira.mongodb.org/browse/SERVER-6102
+    .replace('undefined', '{ "$undefined": true }');
+}
+
+
+function toStrictRegEx(str) {
+  var regex = /([,:]\s*)\/(.+?)\/([gims]{0,4})(\s+)/g;
+  var match;
+
+  while ((match = regex.exec(str)) !== null) {
+    var m2 = match[2].replace(/"/g, '"');
+    str = str.replace(match[0], match[1] + '{ "$regex": "' + m2 + '", "$options": "' + match[3]
+      + '" }' + match[4]);
+  }
+  return str;
+}
+
+function toStrictBinData(str) {
+  var regex = /BinData\((\d+),"(.+?)"\)/g;
+  var match;
+  while ((match = regex.exec(str)) !== null) {
+    var hex = parseInt(match[1], 10).toString(16);
+    str = str.replace(match[0], '{ "$binary": "' + match[2] + '", "$type": "' + hex + '" }');
+  }
+  return str;
+}
+
+module.exports.toStrict = function(str) {
+  str = toStrictQuotes(str);
+  str = toStrictSimple(str);
+  str = toStrictRegEx(str);
+  str = toStrictBinData(str);
+  return str;
+};
+
+/**
+ * Below definitions are currently not used, stringification back to shell mode
+ * is not yet supported. We leave them here for future reference though.
+ */
+module.exports.inflate = {
+  ObjectID: function(v) {
+    return format('ObjectId("%s")', v.toString());
+  },
+  Timestamp: function(v) {
+    return format('Timestamp(%d, %d)', v.low_, v.high_);
+  },
+  MinKey: function(v) {
+    return v;
+  },
+  MaxKey: function(v) {
+    return v;
+  },
+  NumberLong: function(v) {
+    return format('NumberLong(%d)', v);
+  },
+  Date: function(v) {
+    return format('ISODate("%s")', v.toISOString());
+  },
+  DBRef: function(v) {
+    return format('DBRef("%s", "%s")', v.namespace, v.oid.toString());
+  },
+  Undefined: function() {
+    return 'undefined';
+  },
+  RegExp: function(v) {
+    var o = '';
+
+    if (v.global) {
+      o += 'g';
+    }
+    if (v.ignoreCase) {
+      o += 'i';
+    }
+    if (v.multiline) {
+      o += 'm';
+    }
+    return format('/%s/%s', v.source, o);
+  },
+  Binary: function(v) {
+    return format('BinData(%s, "%s")', v.sub_type.toString(10), v.buffer.toString('base64'));
+  }
+};

--- a/lib/modes/strict.js
+++ b/lib/modes/strict.js
@@ -1,0 +1,117 @@
+var bson = require('bson');
+
+/**
+ * Map of all extended types to inflaters (stringify) and deflaters (parse).
+ *
+ * @api private
+ */
+module.exports = {
+  inflate: {
+    ObjectID: function(v) {
+      return {
+        $oid: v.toString()
+      };
+    },
+    Binary: function(v) {
+      return {
+        $binary: v.buffer.toString('base64')
+      };
+    },
+    DBRef: function(v) {
+      return {
+        $ref: v.namespace,
+        $id: v.oid.toString()
+      };
+    },
+    Timestamp: function(v) {
+      return {
+        $timestamp: {
+          $t: v.low_,
+          $i: v.high_
+        }
+      };
+    },
+    Long: function(v) {
+      return {
+        $numberLong: v.toString()
+      };
+    },
+    MaxKey: function() {
+      return {
+        $maxKey: 1
+      };
+    },
+    MinKey: function() {
+      return {
+        $minKey: 1
+      };
+    },
+    Date: function(v) {
+      return {
+        $date: v.toISOString()
+      };
+    },
+    RegExp: function(v) {
+      var o = '';
+
+      if (v.global) {
+        o += 'g';
+      }
+      if (v.ignoreCase) {
+        o += 'i';
+      }
+      if (v.multiline) {
+        o += 'm';
+      }
+
+      return {
+        $regex: v.source,
+        $options: o
+      };
+    },
+    Undefined: function() {
+      return {
+        $undefined: true
+      };
+    }
+  },
+  /*eslint new-cap:0*/
+  deflate: {
+    $oid: function(data) {
+      return bson.ObjectID(data.$oid);
+    },
+    $binary: function(val) {
+      return bson.Binary(new Buffer(val.$binary, 'base64'));
+    },
+    $ref: function(val) {
+      return bson.DBRef(val.$ref, val.$id);
+    },
+    $timestamp: function(val) {
+      return bson.Timestamp(val.$timestamp.$t, val.$timestamp.$i);
+    },
+    $numberLong: function(val) {
+      return bson.Long.fromString(val.$numberLong);
+    },
+    $maxKey: function() {
+      return bson.MaxKey();
+    },
+    $minKey: function() {
+      return bson.MinKey();
+    },
+    $date: function(val) {
+      var d = new Date();
+
+      // Kernel bug.  See #2 http://git.io/AEbmFg
+      if (isNaN(d.setTime(val.$date))) {
+        d = new Date(val.$date);
+      }
+      return d;
+    },
+    $regex: function(val) {
+      return new RegExp(val.$regex, val.$options);
+    },
+    $undefined: function() {
+      return undefined;
+    }
+  }
+};

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,120 +1,4 @@
-var bson = require('bson');
-
-/**
- * Map of all extended types to inflaters (stingify) and defalters (parse).
- *
- * @api private
- */
-module.exports = {
-  inflate: {
-    ObjectID: function(v) {
-      return {
-        $oid: v.toString()
-      };
-    },
-    Binary: function(v) {
-      return {
-        $binary: v.buffer.toString('base64')
-      };
-    },
-    DBRef: function(v) {
-      return {
-        $ref: v.namespace,
-        $id: v.oid.toString()
-      };
-    },
-    Timestamp: function(v) {
-      return {
-        $timestamp: {
-          $t: v.low_,
-          $i: v.high_
-        }
-      };
-    },
-    Long: function(v) {
-      return {
-        $numberLong: v.toString()
-      };
-    },
-    MaxKey: function() {
-      return {
-        $maxKey: 1
-      };
-    },
-    MinKey: function() {
-      return {
-        $minKey: 1
-      };
-    },
-    Date: function(v) {
-      return {
-        $date: v.toISOString()
-      };
-    },
-    RegExp: function(v) {
-      var o = '';
-
-      if (v.global) {
-        o += 'g';
-      }
-      if (v.ignoreCase) {
-        o += 'i';
-      }
-      if (v.multiline) {
-        o += 'm';
-      }
-
-      return {
-        $regex: v.source,
-        $options: o
-      };
-    },
-    Undefined: function() {
-      return {
-        $undefined: true
-      };
-    }
-  },
-  /*eslint new-cap:0*/
-  deflate: {
-    $oid: function(data) {
-      return bson.ObjectID(data.$oid);
-    },
-    $binary: function(val) {
-      return bson.Binary(new Buffer(val.$binary, 'base64'));
-    },
-    $ref: function(val) {
-      return bson.DBRef(val.$ref, val.$id);
-    },
-    $timestamp: function(val) {
-      return bson.Timestamp(val.$timestamp.$t, val.$timestamp.$i);
-    },
-    $numberLong: function(val) {
-      return bson.Long.fromString(val.$numberLong);
-    },
-    $maxKey: function() {
-      return bson.MaxKey();
-    },
-    $minKey: function() {
-      return bson.MinKey();
-    },
-    $date: function(val) {
-      var d = new Date();
-
-      // Kernel bug.  See #2 http://git.io/AEbmFg
-      if (isNaN(d.setTime(val.$date))) {
-        d = new Date(val.$date);
-      }
-      return d;
-    },
-    $regex: function(val) {
-      return new RegExp(val.$regex, val.$options);
-    },
-    $undefined: function() {
-      return undefined;
-    }
-  }
-};
+var strict = require('./modes/strict');
 
 var OBJECT_REGEX = /\[object (\w+)\]/;
 /**
@@ -133,8 +17,8 @@ module.exports.type = function type(value) {
  * @api private
  */
 module.exports.special = {
-  types: Object.keys(module.exports.inflate),
-  keys: Object.keys(module.exports.deflate)
+  types: Object.keys(strict.inflate),
+  keys: Object.keys(strict.deflate)
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "^1.3.0",
     "bson": "~0.4.6",
     "event-stream": "~3.3.1",
-    "raf": "^3.0.0"
+    "raf": "^3.0.0",
     "moment": "^2.10.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "bson": "~0.4.6",
     "event-stream": "~3.3.1",
     "raf": "^3.0.0"
+    "moment": "^2.10.3"
   },
   "devDependencies": {
+    "debug": "^2.2.0",
     "eslint-config-mongodb-js": "^0.1.4",
     "mocha": "~2.2.5",
     "mongodb-js-precommit": "^0.1.2",

--- a/test/logmode.test.js
+++ b/test/logmode.test.js
@@ -1,0 +1,101 @@
+var assert = require('assert');
+var logToStrict = require('../lib/modes/log.js').toStrict;
+var parse = require('../').parse;
+var bson = require('bson');
+
+/*eslint new-cap:0*/
+describe('Parse from log mode', function() {
+  it('should work on a simple example with ObjectId', function() {
+    assert.deepEqual(parse('{"_id": ObjectId(\'53c2b570c15c457669f481f7\') }', null, 'log'), {
+      _id: bson.ObjectID('53c2b570c15c457669f481f7')
+    });
+  });
+
+  it('should work without quotes around field names', function() {
+    assert.deepEqual(parse('{_id: ObjectId(\'53c2b570c15c457669f481f7\') }', null, 'log'), {
+      _id: bson.ObjectID('53c2b570c15c457669f481f7')
+    });
+  });
+});
+
+/*eslint new-cap:0*/
+describe('Log mode -> Strict mode', function() {
+  it('should replace ObjectId', function() {
+    var s = logToStrict('{ oid: ObjectId(\'87654f73c737a19e1d112233\') }');
+    assert.equal(s, '{ "oid": { "$oid": "87654f73c737a19e1d112233" } }');
+  });
+
+  it('should replace Date', function() {
+    var s = logToStrict('{ date: new Date(1388534400000) }');
+    assert.equal(s, '{ "date": { "$date": "2014-01-01T00:00:00.000Z" } }');
+  });
+
+  it('should replace multiple dates in one line', function() {
+    var s = logToStrict('{ start: new Date(1388534400000), end: new Date(1388534406000) }');
+    assert.equal(s, '{ "start": { "$date": "2014-01-01T00:00:00.000Z" }, "end":'
+      + ' { "$date": "2014-01-01T00:00:06.000Z" } }');
+  });
+
+  it('should replace Timestamp', function() {
+    var s = logToStrict('{ ts: Timestamp 0|0 }');
+    assert.equal(s, '{ "ts": { "$timestamp": { "t": 0, "i": 0 } } }');
+  });
+
+  it('should replace RegExp', function() {
+    var s = logToStrict('{ regex: /foo/gi }');
+    assert.equal(s, '{ "regex": { "$regex": "foo", "$options": "gi" } }');
+  });
+
+  it('should escape double quotes in RegExp', function() {
+    var s = logToStrict('{ regex: /foo"bar/ }');
+    assert.equal(s, '{ "regex": { "$regex": "foo"bar", "$options": "" } }');
+  });
+
+  it('should not confuse URLs with RegExp', function() {
+    var s = logToStrict('{ url: "https://www.google.com/accounts/cd/id?abc=123" }');
+    assert.equal(s, '{ "url": "https://www.google.com/accounts/cd/id?abc=123" }');
+  });
+
+  it('should handle RegExp with embedded URLs', function() {
+    var s = logToStrict('{ url: /(?:^|\W)href="http:\/\/www\.google\.com\/indexes'
+      + '\/12345678\/0987654321a\/"/i }');
+    assert.equal(s, '{ "url": { "$regex": "(?:^|\W)href="http:\/\/www\.google\.com\/indexes'
+      + '\/12345678\/0987654321a\/"", "$options": "i" } }');
+  });
+
+  it('should not confuse string paths with RegExp', function() {
+    var s = logToStrict('{ path: "/local/mis" }');
+    assert.equal(s, '{ "path": "/local/mis" }');
+  });
+
+  it('should replace MaxKey', function() {
+    var s = logToStrict('{ val: MaxKey }');
+    assert.equal(s, '{ "val": { "$maxKey": 1 } }');
+  });
+
+  it('should replace MinKey', function() {
+    var s = logToStrict('{ val: MinKey }');
+    assert.equal(s, '{ "val": { "$minKey": 1 } }');
+  });
+
+  it('should replace BinData and convert from hex to base64', function() {
+    var s = logToStrict('{ bin: BinData(0, 48656C6C6F20576F726C64) }');
+    assert.equal(s, '{ "bin": { "$binary": "SGVsbG8gV29ybGQ=", "$type": "0" } }');
+  });
+
+  it('should replace NumberLong', function() {
+    var s = logToStrict('{ long: 9223372036854775807 }');
+    assert.equal(s, '{ "long": { "$numberLong": "9223372036854775807" } }');
+  });
+
+  it('should replace multiple NumberLong in one line', function() {
+    var s = logToStrict('{ long: { $in: [ 9223372036854775807, 9223372036854775806 ] } }');
+    assert.equal(s, '{ "long": { "$in": [ { "$numberLong": "9223372036854775807" }, '
+      + '{ "$numberLong": "9223372036854775806" } ] } }');
+  });
+
+  it('should leave short numbers alone', function() {
+    var s = logToStrict('{ short: 1234567 }');
+    assert.equal(s, '{ "short": 1234567 }');
+  });
+});

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -9,4 +9,8 @@ describe('Parse', function() {
       _id: bson.ObjectID('53c2b570c15c457669f481f7')
     });
   });
+
+  it('should throw an error when using an unknown mode', function() {
+    assert.throws(parse('{"a": 1}', 'invalid_mode'), Error);
+  });
 });

--- a/test/reviver.test.js
+++ b/test/reviver.test.js
@@ -8,25 +8,30 @@ describe('Reviver', function() {
   var user_id = bson.ObjectID();
   var bin = bson.Binary(new Buffer(1));
 
-  var text = EJSON.stringify({
-    _id: _id,
-    download_count: bson.Long.fromNumber(10),
-    tarball: bin,
-    maintainer: bson.DBRef('npm.user', user_id),
-    versions: [
-      {
-        _id: bson.ObjectID(),
-        tag: 'v0.0.2',
-        created_on: new Date()
-      },
-      {
-        _id: bson.ObjectID(),
-        tag: 'v0.0.3',
-        created_on: new Date()
-      }
-    ]
+  var text;
+  var data;
+
+  before(function() {
+    text = EJSON.stringify({
+      _id: _id,
+      download_count: bson.Long.fromNumber(10),
+      tarball: bin,
+      maintainer: bson.DBRef('npm.user', user_id),
+      versions: [
+        {
+          _id: bson.ObjectID(),
+          tag: 'v0.0.2',
+          created_on: new Date()
+        },
+        {
+          _id: bson.ObjectID(),
+          tag: 'v0.0.3',
+          created_on: new Date()
+        }
+      ]
+    });
+    data = JSON.parse(text, EJSON.reviver);
   });
-  var data = JSON.parse(text, EJSON.reviver);
 
   it('should revive `{$numberLong: <str>}` to `bson.Long`', function() {
     assert(data.download_count.equals(bson.Long.fromNumber(10)));

--- a/test/shellmode.test.js
+++ b/test/shellmode.test.js
@@ -1,0 +1,87 @@
+var assert = require('assert');
+var shellToStrict = require('../lib/modes/shell.js').toStrict;
+var parse = require('../').parse;
+var bson = require('bson');
+
+
+/*eslint new-cap:0*/
+describe('Parse from shell mode', function() {
+  it('should work on a simple example with ObjectId', function() {
+    assert.deepEqual(parse('{"_id": ObjectId("53c2b570c15c457669f481f7") }', null, 'shell'), {
+      _id: bson.ObjectID('53c2b570c15c457669f481f7')
+    });
+  });
+
+  it('should work without field name quotes', function() {
+    assert.deepEqual(parse('{_id: ObjectId("53c2b570c15c457669f481f7") }', null, 'shell'), {
+      _id: bson.ObjectID('53c2b570c15c457669f481f7')
+    });
+  });
+
+  it('should work with single instead of double quotes', function() {
+    assert.deepEqual(parse('{\'_id\': ObjectId(\'53c2b570c15c457669f481f7\') }', null, 'shell'), {
+      _id: bson.ObjectID('53c2b570c15c457669f481f7')
+    });
+  });
+});
+
+describe('Shell mode -> Strict mode', function() {
+  it('should replace ObjectId', function() {
+    var s = shellToStrict('{ "_id": ObjectId("87654f73c737a19e1d112233") }');
+    assert.equal(s, '{ "_id": { "$oid": "87654f73c737a19e1d112233" } }');
+  });
+
+  it('should replace Date', function() {
+    var s = shellToStrict('{ "created_at": ISODate("2014-01-01T00:00:00.000Z") }');
+    assert.equal(s, '{ "created_at": { "$date": "2014-01-01T00:00:00.000Z" } }');
+  });
+
+  it('should replace multiple dates in one line', function() {
+    var s = shellToStrict('{ "start": ISODate("2014-01-01T00:00:00.000Z"), "end": '
+      + 'ISODate("2015-01-01T00:00:00.000Z") }');
+    assert.equal(s, '{ "start": { "$date": "2014-01-01T00:00:00.000Z" }, "end": '
+      + '{ "$date": "2015-01-01T00:00:00.000Z" } }');
+  });
+
+  it('should replace Timestamp', function() {
+    var s = shellToStrict('{ "ts": Timestamp(100, 15) }');
+    assert.equal(s, '{ "ts": { "$timestamp": { "t": 100, "i": 15 } } }');
+  });
+
+  it('should replace RegExp', function() {
+    var s = shellToStrict('{ "regex": /foo/gi }');
+    assert.equal(s, '{ "regex": { "$regex": "foo", "$options": "gi" } }');
+  });
+
+  it('should escape double quotes in RegExp', function() {
+    var s = shellToStrict('{ "regex": /foo"bar/ }');
+    assert.equal(s, '{ "regex": { "$regex": "foo"bar", "$options": "" } }');
+  });
+
+  it('should not confuse URLs with RegExp', function() {
+    var s = shellToStrict('{ url: "https://www.google.com/accounts/cd/id?abc=123" }');
+    assert.equal(s, '{ "url": "https://www.google.com/accounts/cd/id?abc=123" }');
+  });
+
+  it('should handle RegExp with embedded URLs', function() {
+    var s = shellToStrict('{ "url": /(?:^|\W)href="http:\/\/www\.google\.com\/index'
+      + 'es\/12345678\/0987654321a\/"/i }');
+    assert.equal(s, '{ "url": { "$regex": "(?:^|\W)href="http:\/\/www\.google\.com\/index'
+      + 'es\/12345678\/0987654321a\/"", "$options": "i" } }');
+  });
+
+  it('should not confuse string paths with RegExp', function() {
+    var s = shellToStrict('{ "path": "/local/mis" }');
+    assert.equal(s, '{ "path": "/local/mis" }');
+  });
+
+  it('should replace BinData', function() {
+    var s = shellToStrict('{ "bin": BinData(0,"SGVsbG8gV29ybGQ=") }');
+    assert.equal(s, '{ "bin": { "$binary": "SGVsbG8gV29ybGQ=", "$type": "0" } }');
+  });
+
+  it('should replace NumberLong', function() {
+    var s = shellToStrict('{ "long": NumberLong(9223372036854775807) }');
+    assert.equal(s, '{ "long": { "$numberLong": "9223372036854775807" } }');
+  });
+});


### PR DESCRIPTION
Also reorganized the files, the 3 different modes are now in a `./modes` subdir.

API is 
```
EJSON.parse(str, reviver, mode)
```

Where mode default is `strict`, but can be set to `shell` or `log`. 