### PR TITLE
DBRef with support for more than a String as an id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var raf = require('raf');
 var format = require('util').format;
 
 function preprocess(text, mode) {
+  console.log('preprocess', text, mode)
   /* eslint indent:0 */
   mode = mode || 'strict';
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ var raf = require('raf');
 var format = require('util').format;
 
 function preprocess(text, mode) {
-  console.log('preprocess', text, mode)
   /* eslint indent:0 */
   mode = mode || 'strict';
 

--- a/lib/modes/shell.js
+++ b/lib/modes/shell.js
@@ -29,7 +29,10 @@ function toStrictSimple(str) {
     // @see https://jira.mongodb.org/browse/SERVER-19171
     .replace(/ISODate\("(.+?)"\)/g, '{ "$date": "$1" }')
     // DBRef
-    .replace(/DBRef\("(.+?)", "(.+?)"\)/g, '{ "$ref": "$1", "$id": "$2" }')
+    .replace(/DBRef\("(.+?)", (.+?)\)/g, function(match, ns, id){
+      id = toStrictSimple(id);
+      return '{ "$ref": "' + ns + '", "$id": ' + id + ' }'
+    })
     // undefined, shell is buggy here too,
     // @see https://jira.mongodb.org/browse/SERVER-6102
     .replace('undefined', '{ "$undefined": true }');
@@ -91,7 +94,13 @@ module.exports.inflate = {
     return format('ISODate("%s")', v.toISOString());
   },
   DBRef: function(v) {
-    return format('DBRef("%s", "%s")', v.namespace, v.oid.toString());
+    var id = typeof v.oid === 'object'
+      && module.exports.inflate[v.oid.constructor.name]
+       ? module.exports.inflate[v.oid.constructor.name](v.oid)
+       : typeof v.oid === 'string'
+         ? '"' + v.oid + '"'
+         : v.oid
+    return format('DBRef("%s", %s)', v.namespace, id);
   },
   Undefined: function() {
     return 'undefined';

--- a/lib/modes/shell.js
+++ b/lib/modes/shell.js
@@ -29,9 +29,9 @@ function toStrictSimple(str) {
     // @see https://jira.mongodb.org/browse/SERVER-19171
     .replace(/ISODate\("(.+?)"\)/g, '{ "$date": "$1" }')
     // DBRef
-    .replace(/DBRef\("(.+?)", (.+?)\)/g, function(match, ns, id){
+    .replace(/DBRef\("(.+?)", (.+?)\)/g, function(match, ns, id) {
       id = toStrictSimple(id);
-      return '{ "$ref": "' + ns + '", "$id": ' + id + ' }'
+      return '{ "$ref": "' + ns + '", "$id": ' + id + ' }';
     })
     // undefined, shell is buggy here too,
     // @see https://jira.mongodb.org/browse/SERVER-6102
@@ -99,7 +99,7 @@ module.exports.inflate = {
        ? module.exports.inflate[v.oid.constructor.name](v.oid)
        : typeof v.oid === 'string'
          ? '"' + v.oid + '"'
-         : v.oid
+         : v.oid;
     return format('DBRef("%s", %s)', v.namespace, id);
   },
   Undefined: function() {

--- a/lib/modes/strict.js
+++ b/lib/modes/strict.js
@@ -8,7 +8,6 @@ var bson = require('bson');
 module.exports = {
   inflate: {
     ObjectID: function(v) {
-      console.log('inflate a DBRef', v)
       return {
         $oid: v.toString()
       };
@@ -23,7 +22,7 @@ module.exports = {
       var id = typeof v.oid === 'object'
         && module.exports.inflate[v.oid.constructor.name]
           ? module.exports.inflate[v.oid.constructor.name](v.oid)
-          : v.oid
+          : v.oid;
       return {
         $ref: v.namespace,
         $id: id
@@ -93,7 +92,7 @@ module.exports = {
       var id = typeof val.$id === 'object'
         && module.exports.deflate[Object.keys(val.$id)[0]]
           ? module.exports.deflate[Object.keys(val.$id)[0]](val.$id)
-          : val.$id
+          : val.$id;
       return bson.DBRef(val.$ref, id);
     },
     $timestamp: function(val) {

--- a/lib/modes/strict.js
+++ b/lib/modes/strict.js
@@ -8,6 +8,7 @@ var bson = require('bson');
 module.exports = {
   inflate: {
     ObjectID: function(v) {
+      console.log('inflate a DBRef', v)
       return {
         $oid: v.toString()
       };
@@ -19,9 +20,13 @@ module.exports = {
       };
     },
     DBRef: function(v) {
+      var id = typeof v.oid === 'object'
+        && module.exports.inflate[v.oid.constructor.name]
+          ? module.exports.inflate[v.oid.constructor.name](v.oid)
+          : v.oid
       return {
         $ref: v.namespace,
-        $id: v.oid.toString()
+        $id: id
       };
     },
     Timestamp: function(v) {
@@ -85,7 +90,11 @@ module.exports = {
       return bson.Binary(new Buffer(val.$binary, 'base64'), parseInt(val.$type, 16));
     },
     $ref: function(val) {
-      return bson.DBRef(val.$ref, val.$id);
+      var id = typeof val.$id === 'object'
+        && module.exports.deflate[Object.keys(val.$id)[0]]
+          ? module.exports.deflate[Object.keys(val.$id)[0]](val.$id)
+          : val.$id
+      return bson.DBRef(val.$ref, id);
     },
     $timestamp: function(val) {
       return bson.Timestamp(val.$timestamp.$t, val.$timestamp.$i);

--- a/test/deflate.test.js
+++ b/test/deflate.test.js
@@ -7,6 +7,7 @@ describe('Deflate', function() {
   var _id = bson.ObjectID();
   var bin = bson.Binary(new Buffer(1));
   var ref = bson.DBRef('local.startup_log', _id);
+  var refStringId = bson.DBRef('local.startup_log', _id.toString());
 
   it('converts `{$numberLong: <str>}` to `bson.Long`', function() {
     assert(deflate({
@@ -39,11 +40,20 @@ describe('Deflate', function() {
       bin.buffer.toString('base64'));
   });
 
-  it('converts `{$ref: <namespace>, $id: <id>}` to `bson.DBRef`', function() {
+  it('converts `{$ref: <namespace>, $id: <string>}` to `bson.DBRef`', function() {
     assert.deepEqual(
       deflate({
         $ref: 'local.startup_log',
         $id: _id.toString()
+      }).toString(),
+      refStringId.toString());
+  });
+
+  it('converts `{$ref: <namespace>, $id: <ObjectID>}` to `bson.DBRef`', function() {
+    assert.deepEqual(
+      deflate({
+        $ref: 'local.startup_log',
+        $id: {$oid: _id.toString()}
       }).toString(),
       ref.toString());
   });

--- a/test/inflate.test.js
+++ b/test/inflate.test.js
@@ -7,6 +7,7 @@ describe('Inflate', function() {
   var _id = bson.ObjectID();
   var bin = bson.Binary(new Buffer(1));
   var ref = bson.DBRef('local.startup_log', _id);
+  var refStringId = bson.DBRef('local.startup_log', _id.toString());
 
   it('is a passthrough for primitive types', function() {
     assert.equal(inflate('bson'), 'bson');
@@ -53,10 +54,17 @@ describe('Inflate', function() {
     });
   });
 
-  it('converts `bson.DBRef` to `{$ref: <namespace>, $id: <id>}`', function() {
-    assert.deepEqual(inflate(ref), {
+  it('converts `bson.DBRef` to `{$ref: <namespace>, $id: <string>}`', function() {
+    assert.deepEqual(inflate(refStringId), {
       $ref: 'local.startup_log',
       $id: _id.toString()
+    });
+  });
+
+  it('converts `bson.DBRef` to `{$ref: <namespace>, $id: <ObjectID>}`', function() {
+    assert.deepEqual(inflate(ref), {
+      $ref: 'local.startup_log',
+      $id: {$oid: _id.toString()}
     });
   });
 


### PR DESCRIPTION
This required to get consistent parsing and stringification back and forth.

Given that a document's `_id` might be of any BSON type, DBRef should support any type as their id.

I'm fully aware this is probably not a really popular feature, but we do require supporting all options at Compose since the usage of our databases vary wildly.

I don't think this code is quite right, it only partially works since it doesn't really support all types, it supports most of them, but not Array or Object. To achieve that, I think a more complex refactor would be in order.

I guess this serves a bit more as a proof of concept and as a "poke" to get this fixed. For now we're obligated to use our fork of this nice library.