### PR TITLE
:bug: Uncaught TypeError: EJSON.inflate is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,23 @@ module.exports.deserialize = deserialize;
 module.exports.serialize = serialize;
 module.exports.reviver = require('./reviver');
 
+var deprecate = require('deprecate');
+
+/**
+ * Backwards compat for 1.x
+ */
+ module.exports.deflate = function() {
+   deprecate('EJSON.deflate() has been deprecated in favor of EJSON.deserialize() '
+     + 'and will be removed in the 2.x release.');
+   return deserialize.apply(null, arguments);
+ };
+
+ module.exports.inflate = function() {
+   deprecate('EJSON.inflate() has been deprecated in favor of EJSON.serialize() '
+     + 'and will be removed in the 2.x release.');
+   return serialize.apply(null, arguments);
+ };
+
 // JSONStream.stringify
 module.exports.createStringifyStream = function(op, sep, cl, indent) {
   indent = indent || 0;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "JSONStream": "~1.0.6",
     "async": "^1.4.2",
     "bson": "~0.4.12",
+    "deprecate": "^0.1.0",
     "event-stream": "~3.3.1",
     "lodash.isfunction": "^3.0.6",
     "lodash.transform": "^3.0.4",

--- a/test/regressions.test.js
+++ b/test/regressions.test.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+var EJSON = require('../');
+var isFunction = require('lodash.isfunction');
+var bson = require('bson');
+
+/* eslint new-cap:0 */
+describe('Regressions', function() {
+  /**
+   * NOTE (imlucas) sorry I missed this but
+   * http://github.com/mongodb-js/extended-json/pulls/24
+   * should have been a version bump to 2.x.
+   */
+  describe('TypeError: EJSON.inflate is not a function', function() {
+    var doc = {
+      _id: bson.ObjectID('5671d0902515a6bc614d5a79')
+    };
+
+    var serialized = {
+      _id: {
+        $oid: '5671d0902515a6bc614d5a79'
+      }
+    };
+
+    it('should have an inflate alias function for serialize', function() {
+      assert(isFunction(EJSON.inflate));
+      assert.deepEqual(EJSON.inflate(doc), EJSON.serialize(doc));
+    });
+
+    it('should have a deflate alias function for deserialize', function() {
+      assert(isFunction(EJSON.deflate));
+      assert.deepEqual(EJSON.deflate(serialized), EJSON.deserialize(serialized));
+    });
+  });
+});


### PR DESCRIPTION
my bad.  mongodb-js/extended-json#24 should have been a major version
bump to 2.x.

This patch adds aliases for EJSON.deflate/inflate to print deprecation
warnings and properly forward to deserialize/serialize.

HT @ksuarz

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb-js/extended-json/27)
<!-- Reviewable:end -->
