### PR TITLE
explicitly call toHexString on ObjectId's

### DIFF
--- a/lib/modes/strict.js
+++ b/lib/modes/strict.js
@@ -9,7 +9,7 @@ module.exports = {
   serialize: {
     ObjectID: function(v) {
       return {
-        $oid: v.toString()
+        $oid: bson.ObjectID.prototype.toHexString.call(v)
       };
     },
     Binary: function(v) {


### PR DESCRIPTION
This will properly serialize objects that look like
```
{
  _bsontype: "ObjectId",
  id: "SÂµpÁ\\Eviô"
}
```
even when the toString method has been changed.