### PR TITLE
fix #77, support '$date: {$numberLong: timestamp}}'

### DIFF
--- a/lib/modes/strict.js
+++ b/lib/modes/strict.js
@@ -56,6 +56,15 @@ module.exports = {
       };
     },
     Date: function(v) {
+      var timestamp = v.getTime();
+      if (timestamp >= 32535215999000) {
+        return {
+          $date: {
+            $numberLong: '' + timestamp
+          }
+        };
+      }
+
       return {
         $date: v.toISOString()
       };
@@ -115,10 +124,16 @@ module.exports = {
     },
     $date: function(val) {
       var d = new Date();
+      var v;
 
+      if (typeof val.$date === 'object') {
+        v = val.$date.$numberLong;
+      } else {
+        v = val.$date;
+      }
       // Kernel bug.  See #2 http://git.io/AEbmFg
-      if (isNaN(d.setTime(val.$date))) {
-        d = new Date(val.$date);
+      if (isNaN(d.setTime(v))) {
+        d = new Date(v);
       }
       return d;
     },

--- a/test/deserialize.test.js
+++ b/test/deserialize.test.js
@@ -104,6 +104,15 @@ describe('Deserialize', function() {
     }), d);
   });
 
+  it('converts `{$date: {$numberLong: <ISO-8601>}}` to `Date`', function() {
+    var d = new Date();
+    assert.deepEqual(deserialize({
+      $date: {
+        $numberLong: '' + d.getTime()
+      }
+    }), d);
+  });
+
   it('converts `{$regex: <pattern>, $options: <flags>}` to `RegExp`', function() {
     assert.deepEqual(deserialize({
       $regex: 'mongodb.com$',

--- a/test/serialize.test.js
+++ b/test/serialize.test.js
@@ -98,9 +98,18 @@ describe('Serialize', function() {
   });
 
   it('converts `Date` to `{$date: <ISO-8601>}`', function() {
-    var d = new Date();
+    var d = new Date(32535215998999);
     assert.deepEqual(serialize(d), {
       $date: d.toISOString()
+    });
+  });
+
+  it('converts `Date` to `{$date: {$numberLong: <ISO-8601>}}`', function() {
+    var d = new Date(32535215999000);
+    assert.deepEqual(serialize(d), {
+      $date: {
+        $numberLong: '' + d.getTime()
+      }
     });
   });
 


### PR DESCRIPTION
refer: 
https://github.com/mongodb/mongo/blob/6471618952c8727bc5b06039ed2cf861e1a36436/src/mongo/gotools/common/json/json_format.go#L46
https://github.com/mongodb/mongo/blob/6471618952c8727bc5b06039ed2cf861e1a36436/src/mongo/gotools/common/json/mongo_extjson.go#L103

