### PR TITLE
fix: prefer _bsontype over constructor.name in DBRef serializer

### DIFF
--- a/lib/modes/shell.js
+++ b/lib/modes/shell.js
@@ -111,9 +111,10 @@ module.exports.serialize = {
 
     if (
       typeof v.oid === 'object' &&
-      module.exports.serialize[v.oid.constructor.name]
+      v.oid !== null &&
+      (module.exports.serialize[v.oid._bsontype] || module.exports.serialize[v.oid.constructor.name])
     ) {
-      id = module.exports.serialize[v.oid.constructor.name](v.oid);
+      id = (module.exports.serialize[v.oid._bsontype] || module.exports.serialize[v.oid.constructor.name])(v.oid);
     } else if (typeof v.oid === 'string') {
       id = '"' + v.oid + '"';
     } else {

--- a/lib/modes/strict.js
+++ b/lib/modes/strict.js
@@ -30,8 +30,9 @@ module.exports = {
       };
     },
     DBRef: function(v) {
-      var id = typeof v.oid === 'object'
-      && module.exports.serialize[v.oid.constructor.name] ? module.exports.serialize[v.oid.constructor.name](v.oid)
+      var id = typeof v.oid === 'object' && v.oid !== null &&
+        (module.exports.serialize[v.oid._bsontype] || module.exports.serialize[v.oid.constructor.name]) ?
+        (module.exports.serialize[v.oid._bsontype] || module.exports.serialize[v.oid.constructor.name])(v.oid)
         : v.oid;
       return {
         $ref: v.namespace,


### PR DESCRIPTION
For compatibility with BSON 4.x.